### PR TITLE
migrate to new manifest format

### DIFF
--- a/lib/bridgetown-docs-template.rb
+++ b/lib/bridgetown-docs-template.rb
@@ -2,8 +2,10 @@
 
 require "bridgetown"
 
-Bridgetown::PluginManager.new_source_manifest(
-  origin: BridgetownDocsTemplate,
-  components: File.expand_path("../components", __dir__),
-  layouts: File.expand_path("../layouts", __dir__)
-)
+Bridgetown.initializer :"bridgetown-docs-template" do |config|
+  config.source_manifest(
+    origin: BridgetownDocsTemplate,
+    components: File.expand_path("../components", __dir__),
+    layouts: File.expand_path("../layouts", __dir__)
+  )
+end

--- a/lib/bridgetown-docs-template.rb
+++ b/lib/bridgetown-docs-template.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "bridgetown"
+require "bridgetown-docs-template/version"
 
 Bridgetown.initializer :"bridgetown-docs-template" do |config|
   config.source_manifest(


### PR DESCRIPTION
Newer versions of Bridgetown complain with:

```
[Bridgetown]        Deprecation: The BridgetownDocsTemplate plugin should switch from using `new_source_manifest' to the `source_manifest` initializer method
```

This PR sets the config to use this new format. 