### PR TITLE
Add suggestion on how to configure tailwind `content`

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,20 @@ content: [
 ]
 ```
 
+One way this can be achieved without hardcoding paths is as follows:
+
+```js
+const execSync = require("child_process").execSync;
+const gemPath = execSync("bundle show bridgetown-docs-template", { encoding: "utf-8" }).trim();
+
+module.exports = {
+  content: [
+    ...,
+    gemPath + "/**/*.{html,md,liquid,erb,serb,rb}",
+  ],
+  ...
+}
+```
 
 ## Configuring views/components
 


### PR DESCRIPTION
Thanks for the template!

This is just a small README suggestion which includes a way to configure the content section of the tailwind config without needed to know the path to your gem installation